### PR TITLE
Fix code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -197,13 +197,13 @@ func (g *Gallery) Create(profile *OctoProfile) error {
 func (g Gallery) Update(profile *OctoProfile) error {
 	db := GetDb()
 
-	stmt, err := db.Prepare(fmt.Sprintf("UPDATE gallery SET title = '%s', description = '%s' WHERE id = %d and login = '%s'", g.Title, g.Description, g.ID, profile.Login))
+	stmt, err := db.Prepare("UPDATE gallery SET title = ?, description = ? WHERE id = ? and login = ?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	r , err := stmt.Exec()
+	r , err := stmt.Exec(g.Title, g.Description, g.ID, profile.Login)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes [https://github.com/Training-BancoPichincha/ghas/security/code-scanning/4](https://github.com/Training-BancoPichincha/ghas/security/code-scanning/4)

To fix the problem, we need to use parameterized queries instead of constructing SQL queries with `fmt.Sprintf`. This involves using placeholders (`?`) in the SQL query and passing the user-provided data as arguments to the `Exec` method. This approach ensures that the data is properly escaped and prevents SQL injection attacks.

- Replace the `fmt.Sprintf` call with a parameterized query using placeholders.
- Pass the user-provided data as arguments to the `Exec` method.
- Ensure that the `Prepare` method is used correctly with the parameterized query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
